### PR TITLE
docs: restructure README with entry points, setup guide, and API reference

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -161,18 +161,17 @@ NotroTail は Astro の静的出力モードを使用しています。SSR ア�
 
 | パッケージ | パス | 役割 |
 |---|---|---|
-| [`remark-nfm`](./packages/remark-nfm/) | `packages/remark-nfm/` | Notion Flavored Markdown 向けの remark プラグイン。前処理（10 件の修正）・`:::callout` ディレクティブ構文・コールアウト変換をまとめたもの。Astro / Notion API 非依存で npm に単独公開可能。 |
-| [`notro-loader`](./packages/notro-loader/) | `packages/notro-loader/` | Astro + Notion API 統合ライブラリ。Content Loader・MDX コンパイルパイプライン（内部で `remark-nfm` を使用）・ヘッドレス Astro コンポーネントを提供。 |
+| [`notro-loader`](./packages/notro-loader/) | `packages/notro-loader/` | Astro + Notion API 統合ライブラリ。Content Loader、Sätteri MDX コンパイルパイプライン（Notion Markdownの正規化を含む）、全 Notion ブロック型に対応したヘッドレス Astro コンポーネントを提供します。使い方は [`notro-loader` README](./packages/notro-loader/README.ja.md) を参照してください。 |
 | [`notro-ui`](./packages/notro-ui/) | `packages/notro-ui/` | `notro-loader` 向けのコピー所有型スタイル済みコンポーネント（shadcn と同じ思想）。`notro-ui add --all` でプロジェクトにコンポーネントをインストール — インストール後はあなたのコードになり、直接編集できます。 |
-| [`rehype-beautiful-mermaid`](./packages/rehype-beautiful-mermaid/) | `packages/rehype-beautiful-mermaid/` | Mermaid コードブロックをビルド時にインライン SVG にレンダリングする rehype プラグイン。 |
+| [`satteri-beautiful-mermaid`](./packages/satteri-beautiful-mermaid/) | `packages/satteri-beautiful-mermaid/` | Mermaid コードブロックをビルド時にインライン SVG にレンダリングする Sätteri hast プラグイン。 |
 | [`create-notro`](./packages/create-notro/) | `packages/create-notro/` | CLI スキャフォールディングツール。`npm create notro@latest` でテンプレートを選択してサイトを作成。 |
-| `notro-blog` (blog) | `templates/blog/` | フル機能ブログテンプレート。リファレンス実装として使用され、`create-notro`（`npm create notro@latest`）でも取得できます。 |
+| `notro-blog` (blog) | `templates/blog/` | フル機能ブログテンプレート — ブログ一覧・タグ・ページネーション・RSS・SEO を備えたリファレンス実装。 |
 | `notro-blank` (blank) | `templates/blank/` | 最小構成スターター。ページ一覧と Notion コンテンツのレンダリングのみ。 |
 | `docs` | `docs/` | Astro Starlight で構築されたドキュメントサイト。 |
 
 **依存関係グラフ:**
 ```
-remark-nfm  ←  notro-loader  ←  notro-ui  ←  notro-blog
+notro-loader  ←  notro-ui  ←  templates/blog
                                      ↑               ↑
                                create-notro  →  templates/blank
 ```
@@ -189,7 +188,7 @@ Notion API はページコンテンツを約 **20,000 ブロック**で切り詰
 
 一部の Notion ブロック型は Notion API によって Markdown に変換されず、レスポンスから無言で除外されます。notro は除外されたブロックの ID を警告ログに出力するので、該当コンテンツを確認・修正できます。
 
-詳細は [Notion API ドキュメント](https://developers.notion.com/reference/retrieve-page-markdown) および [`notro-loader` README](./packages/notro-loader/README.md#notion-api-limitations) を参照してください。
+詳細は [Notion API ドキュメント](https://developers.notion.com/reference/retrieve-page-markdown) および [`notro-loader` README](./packages/notro-loader/README.ja.md#notion-apiの制約) を参照してください。
 
 ## Contributing
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,8 +8,6 @@
 <a href="./README.ko.md">한국어</a>-->
 </p>
 
-![NotroTail.webp](docs%2Fpublic%2FNotroTail.webp)
-
 <p align="center">
 <a href="https://notrotail.mosugi.com">WebSite</a>
  | 
@@ -28,8 +26,6 @@
  | 
 <a href="https://notrotail.mosugi.com">NotroTail</a>
 </p>
-
-![BeforeAfter.png](docs%2Fpublic%2FBeforeAfter.png)
 
 ## クイックスタート
 
@@ -165,9 +161,12 @@ NotroTail は Astro の静的出力モードを使用しています。SSR ア�
 | [`notro-ui`](./packages/notro-ui/) | `packages/notro-ui/` | `notro-loader` 向けのコピー所有型スタイル済みコンポーネント（shadcn と同じ思想）。`notro-ui add --all` でプロジェクトにコンポーネントをインストール — インストール後はあなたのコードになり、直接編集できます。 |
 | [`satteri-beautiful-mermaid`](./packages/satteri-beautiful-mermaid/) | `packages/satteri-beautiful-mermaid/` | Mermaid コードブロックをビルド時にインライン SVG にレンダリングする Sätteri hast プラグイン。 |
 | [`create-notro`](./packages/create-notro/) | `packages/create-notro/` | CLI スキャフォールディングツール。`npm create notro@latest` でテンプレートを選択してサイトを作成。 |
+| [`notro-md-sync`](./packages/notro-md-sync/) | `packages/notro-md-sync/` | ローカルのMarkdownファイルとNotionデータソース間で双方向同期を行うCLIツール。 |
 | `notro-blog` (blog) | `templates/blog/` | フル機能ブログテンプレート — ブログ一覧・タグ・ページネーション・RSS・SEO を備えたリファレンス実装。 |
 | `notro-blank` (blank) | `templates/blank/` | 最小構成スターター。ページ一覧と Notion コンテンツのレンダリングのみ。 |
-| `docs` | `docs/` | Astro Starlight で構築されたドキュメントサイト。 |
+| `notro-basics` (basics) | `templates/basics/` | 最小構成のブログスターター。Notionデータベースをpostsコレクションとして描画しますが、フル機能ブログのタグ・ページネーション・RSSはありません。 |
+| `notro-gallery` (gallery) | `templates/gallery/` | ポートフォリオ／作品ギャラリー用スターター。Notionデータベースをタグ付きのworksコレクションとして描画します。 |
+| `notro-docs` (docs) | `templates/docs/` | Astro Starlight で構築されたドキュメントサイト — [notrotail.mosugi.com/doc](https://notrotail.mosugi.com/doc) はこのテンプレートから生成されています。 |
 
 **依存関係グラフ:**
 ```

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ This repository is a **pnpm workspace monorepo** containing the following packag
 
 | Package | Path | Role |
 |---|---|---|
-| [`notro-loader`](./packages/notro-loader/) | `packages/notro-loader/` | Astro + Notion API integration library. Provides the Content Loader, the Sätteri MDX compile pipeline (including Notion markdown normalization), and headless Astro components for all Notion block types. |
+| [`notro-loader`](./packages/notro-loader/) | `packages/notro-loader/` | Astro + Notion API integration library. Provides the Content Loader, the Sätteri MDX compile pipeline (including Notion markdown normalization), and headless Astro components for all Notion block types. See the [`notro-loader` README](./packages/notro-loader/README.md) for usage. |
 | [`notro-ui`](./packages/notro-ui/) | `packages/notro-ui/` | Copy-and-own styled components for `notro-loader` (shadcn style). Run `notro-ui add --all` to install components into your project — they become your code, editable directly. |
 | [`satteri-beautiful-mermaid`](./packages/satteri-beautiful-mermaid/) | `packages/satteri-beautiful-mermaid/` | Sätteri hast plugin that renders Mermaid code blocks to inline SVG at build time. |
 | [`create-notro`](./packages/create-notro/) | `packages/create-notro/` | CLI scaffolding tool. Run `npm create notro@latest` to choose a template and scaffold a new site. |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 <a href="./README.ko.md">한국어</a>-->
 </p>
 
-![NotroTail.webp](docs%2Fpublic%2FNotroTail.webp)
-
 <p align="center">
 <a href="https://notrotail.mosugi.com">Website</a>
  | 
@@ -29,8 +27,6 @@
 <a href="https://notrotail.mosugi.com">NotroTail</a>
 </p>
 
-![BeforeAfter.png](docs%2Fpublic%2FBeforeAfter.png)
-
 ## Quick Start
 
 ```sh
@@ -39,7 +35,7 @@ npm create notro@latest my-site
 
 The CLI will download the starter template, create `.env` from `.env.example`, and optionally install dependencies. Then edit `.env` with your Notion credentials and run `npm run dev`.
 
-See the [documentation](https://github.com/mosugi/notro/tree/main/docs) for detailed setup instructions.
+See the [documentation](https://github.com/mosugi/notro/tree/main/templates/docs) for detailed setup instructions.
 
 ## Features
 
@@ -171,9 +167,12 @@ This repository is a **pnpm workspace monorepo** containing the following packag
 | [`notro-ui`](./packages/notro-ui/) | `packages/notro-ui/` | Copy-and-own styled components for `notro-loader` (shadcn style). Run `notro-ui add --all` to install components into your project — they become your code, editable directly. |
 | [`satteri-beautiful-mermaid`](./packages/satteri-beautiful-mermaid/) | `packages/satteri-beautiful-mermaid/` | Sätteri hast plugin that renders Mermaid code blocks to inline SVG at build time. |
 | [`create-notro`](./packages/create-notro/) | `packages/create-notro/` | CLI scaffolding tool. Run `npm create notro@latest` to choose a template and scaffold a new site. |
+| [`notro-md-sync`](./packages/notro-md-sync/) | `packages/notro-md-sync/` | CLI tool for bidirectional sync between local markdown files and a Notion data source. |
 | `notro-blog` (blog) | `templates/blog/` | Full-featured blog template — reference implementation with blog list, tags, pagination, RSS, and SEO. |
 | `notro-blank` (blank) | `templates/blank/` | Minimal starter — just pages and Notion content rendering. |
-| `docs` | `docs/` | Documentation site built with Astro Starlight. |
+| `notro-basics` (basics) | `templates/basics/` | Minimal blog starter — a Notion database rendered as a posts collection, without the full blog template's tags/pagination/RSS. |
+| `notro-gallery` (gallery) | `templates/gallery/` | Portfolio/works gallery starter, rendering a Notion database as a tagged works collection. |
+| `notro-docs` (docs) | `templates/docs/` | Documentation site built with Astro Starlight — this is what powers [notrotail.mosugi.com/doc](https://notrotail.mosugi.com/doc). |
 
 **Dependency graph:**
 ```

--- a/packages/notro-loader/README.ja.md
+++ b/packages/notro-loader/README.ja.md
@@ -1,0 +1,376 @@
+# notro-loader
+
+<p>
+<a href="README.md">English</a>
+ | 
+<a href="./README.ja.md">日本語</a>
+</p>
+
+![npm](https://img.shields.io/npm/v/notro-loader)
+![License: MIT](https://img.shields.io/badge/license-MIT-blue)
+
+Notionデータベースのコンテンツを[Markdown Content API](https://developers.notion.com/)経由で取得し、[Astro Content Collections](https://docs.astro.build/en/guides/content-collections/)に取り込むAstro Content Loaderライブラリです。取得したMarkdownはSätteri（Astro 7のRust製Markdown/MDXプロセッサ）でコンパイルし、Notionの各ブロック種別に対応したコンポーネント一式で描画します。
+
+> [!TIP]
+> このパッケージは[mosugi/notro](https://github.com/mosugi/notro)モノレポの一部です。動作するサンプルとして`templates/blog/`のブログテンプレートを参照してください。
+
+## 目次
+
+- [エントリーポイント](#エントリーポイント)
+- [インストール](#インストール)
+- [セットアップ](#セットアップ)
+  1. [`astro.config.mjs`](#1-astroconfigmjs)
+  2. [`src/content.config.ts`](#2-srccontentconfigts)
+  3. [ページコンポーネント](#3-ページコンポーネント)
+- [`NotroContent`が描画するもの](#notrocontentが描画するもの)
+- [画像の扱い](#画像の扱い)
+- [Markdown前処理（`preprocessNotionMarkdown`）](#markdown前処理preprocessnotionmarkdown)
+- [Notion APIの制約](#notion-apiの制約)
+- [環境変数](#環境変数)
+- [APIリファレンス](#apiリファレンス)
+
+## エントリーポイント
+
+`notro-loader`は、それぞれ利用可能な場所が異なる4つのエントリーポイントを公開しています。
+
+| エントリーポイント | インポート | 用途 |
+|---|---|---|
+| `notro-loader` | `import { NotroContent, loader, ... } from "notro-loader"` | AstroコンポーネントとContent Loader用。**`astro.config.mjs`では使用できません**（AstroのconfigはJSXレンダラーが登録される前に評価されるため） |
+| `notro-loader/utils` | `import { getPlainText, preprocessNotionMarkdown, ... } from "notro-loader/utils"` | Astroコンポーネントへの依存がない純粋なTypeScriptヘルパー。configファイルやNodeスクリプト、画像サービスなどどこでも安全に利用できます |
+| `notro-loader/integration` | `import { notro } from "notro-loader/integration"` | `notro()` Astroインテグレーション。`astro.config.mjs`で`@astrojs/mdx`を正しいSätteriプラグインパイプラインと共に登録するために使用します |
+| `notro-loader/image-service` | `import { notionImageService } from "notro-loader/image-service"` | Notion S3の署名付きURLから、キャッシュキー計算前に期限切れとなる`X-Amz-*`クエリパラメータを取り除くAstro画像サービス。`astro.config.mjs`の`image.service`で使用します |
+
+## インストール
+
+```sh
+npx astro add notro-loader
+```
+
+これによりパッケージがインストールされ、`astro.config.mjs`に`notro()`インテグレーションが自動的に追加されます。
+
+手動でインストールする場合は次のようにします。
+
+```sh
+npm install notro-loader
+```
+
+## セットアップ
+
+### 1. `astro.config.mjs`
+
+`astro add notro-loader`を実行すると自動的に設定されます。手動でインストールした場合は、インテグレーションと（任意で）画像サービスを追加してください。
+
+```js
+import { defineConfig } from "astro/config";
+import { notro } from "notro-loader/integration";
+import { notionImageService } from "notro-loader/image-service";
+
+export default defineConfig({
+  image: { service: notionImageService },
+  integrations: [notro()],
+});
+```
+
+`notro()`は、必要なSätteriプラグインパイプラインと、`NotroContent`が実行時に依存する`astro:jsx`レンダラーを備えた状態で`@astrojs/mdx`を登録します。オプションを指定しない場合、色クラス・コンポーネントのリネーム・見出しスラッグ・目次・ページリンク解決といったnotroのコアプラグインのみが適用されます。リッチな機能はオプトインです。
+
+| オプション | 型 | 用途 |
+|---|---|---|
+| `mdastPlugins` | `MdastPluginInput[]` | notroのコアプラグインの後に実行されるSätteri mdastプラグイン（例：数式描画用のKaTeXプラグイン） |
+| `hastPlugins` | `HastPluginInput[]` | リネーム後、見出しスラッグ/目次の前に実行されるSätteri hastプラグイン（例：[`satteri-beautiful-mermaid`](https://github.com/mosugi/notro/tree/main/packages/satteri-beautiful-mermaid)） |
+| `features` | `Features` | notroのデフォルト設定にマージされる追加のSätteriパーサー機能（例：`{ math: true }`） |
+| `shikiConfig` | `Record<string, unknown>` | Shikiシンタックスハイライトのhastプラグインを、ユーザープラグインの最後に自動的に注入する（`npm install shiki`が必要）。例：`{ theme: 'github-dark' }` |
+| `viteExternals` | `string[]` | ViteのSSR外部化リスト（`ssr.external`）に追加するパッケージ（ネイティブバイナリや動的インポートを使うパッケージ向け） |
+| `extendMarkdownConfig` | `boolean` | Astroのベースmarkdown設定を拡張するかどうか（デフォルト：`false`） |
+
+remark/rehypeプラグインは**サポートされていません** — Astro 7では`markdown.remarkPlugins` / `rehypePlugins`が非推奨となり、Sätteriはこれらを実行できません。代わりにSätteriのmdast/hastプラグインAPIを使用してください（[ドキュメント](https://satteri.bruits.org/docs/plugins/)）。
+
+```js
+import { defineConfig } from "astro/config";
+import { notro } from "notro-loader/integration";
+import { satteriMermaid } from "satteri-beautiful-mermaid";
+
+export default defineConfig({
+  integrations: [
+    notro({
+      shikiConfig: { theme: "github-dark" },
+      features: { math: true },
+      hastPlugins: [satteriMermaid({ theme: "github-dark" })],
+    }),
+  ],
+});
+```
+
+### 2. `src/content.config.ts`
+
+`loader`関数を使ってコレクションを定義します。`pageWithMarkdownSchema`をデータベースのプロパティで拡張してください。プロパティスキーマは`notroProperties`のショートハンドを使うと簡潔に書けます。
+
+```typescript
+import { defineCollection } from "astro:content";
+import { loader, pageWithMarkdownSchema, notroProperties } from "notro-loader";
+import { z } from "zod";
+
+const posts = defineCollection({
+  loader: loader({
+    queryParameters: {
+      data_source_id: import.meta.env.NOTION_DATASOURCE_ID,
+      filter: {
+        property: "Public",
+        checkbox: { equals: true },
+      },
+    },
+    clientOptions: {
+      auth: import.meta.env.NOTION_TOKEN,
+    },
+  }),
+  schema: pageWithMarkdownSchema.extend({
+    properties: z.object({
+      Name: notroProperties.title,
+      Description: notroProperties.richText,
+      Public: notroProperties.checkbox,
+      Tags: notroProperties.multiSelect,
+      Date: notroProperties.date,
+    }),
+  }),
+});
+
+export const collections = { posts };
+```
+
+`loader(options)`が受け取るオプションは次のとおりです。
+
+| オプション | 型 | 用途 |
+|---|---|---|
+| `queryParameters` | `QueryDataSourceParameters` | Notion APIの`dataSources.query`にそのまま渡されます |
+| `clientOptions` | `ConstructorParameters<typeof Client>[0]` | `@notionhq/client`のコンストラクタに渡されます（例：`{ auth }`） |
+| `generateId` | `(page) => string`（任意） | ページごとのカスタムエントリーIDを生成する関数。デフォルトはNotionページのUUID。エントリーIDを特定の形式に合わせる必要がある場合（例：Starlightのサイドバースラグ）に使用します |
+| `useFilePath` | `boolean`（任意、デフォルト`false`） | 各ストアエントリーに合成の`filePath`を設定し、Starlightのサイドバー自動生成がルートパスを解決できるようにします。`@astrojs/starlight`を使う場合のみ必要です |
+
+Loaderは`last_edited_time`のダイジェストでページをキャッシュし、削除・編集された、あるいはNotionの署名付きS3 URLが期限切れになったエントリーのみを再取得します。
+
+Astroの[Live Content Collections](https://docs.astro.build/en/guides/content-collections/#live-content-collections)向けのライブリロード版も用意されています。
+
+```typescript
+import { liveLoader } from "notro-loader";
+```
+
+`loader()`と同じ`queryParameters` / `clientOptions`の形式を受け取ります。
+
+### 3. ページコンポーネント
+
+#### オプションA — ヘッドレス（スタイルなし）
+
+`notro-loader`の`NotroContent`は、クラス指定のないセマンティックなHTMLを描画します。
+
+```astro
+---
+import { NotroContent, getPlainText } from "notro-loader";
+
+const { entry } = Astro.props;
+const title = getPlainText(entry.data.properties.Name);
+---
+
+<h1>{title}</h1>
+<NotroContent markdown={entry.data.markdown} />
+```
+
+#### オプションB — notro-uiを使う
+
+スタイル付きコンポーネントを一度だけインストールします。
+
+```sh
+npx notro-ui init
+```
+
+その後、コンポーネントマップを`NotroContent`に渡します。
+
+```astro
+---
+import { NotroContent, getPlainText } from "notro-loader";
+import { notroComponents } from "@/components/notro";
+
+const { entry } = Astro.props;
+---
+
+<NotroContent markdown={entry.data.markdown} components={notroComponents} />
+```
+
+コンポーネントは`src/components/notro/`にコピーされるため、直接編集できます。詳細は[notro-ui](https://github.com/mosugi/notro/tree/main/packages/notro-ui)を参照してください。
+
+`NotroContent`の任意プロパティ：
+
+| プロパティ | 型 | 用途 |
+|---|---|---|
+| `linkToPages` | `Record<string, { url: string; title: string }>` | Notionのページ内リンクを解決します。`buildLinkToPages()`で構築します |
+| `classMap` | `Partial<Record<ClassMapKeys, string>>` | デフォルトコンポーネントを置き換えずにTailwindクラスを注入します |
+| `components` | `Partial<NotionComponents>` | コンポーネントの完全な上書き（例：`{ Callout: MyCallout }`） |
+
+## `NotroContent`が描画するもの
+
+`NotroContent`はNotionのMarkdownをHTMLにコンパイルします。各Notionブロック種別はデフォルトでセマンティックなHTML要素にマッピングされます。`components`プロパティで任意の要素を独自のスタイル付きコンポーネントに置き換えられます。
+
+| Notionブロック | デフォルトのHTML | notro-uiコンポーネント |
+|---|---|---|
+| 段落 | `<p>` | `ColoredParagraph` |
+| 見出し1〜4 | `<h1>`〜`<h4>` | `H1`〜`H4` |
+| コールアウト | `<aside>` | `Callout` |
+| 引用 | `<blockquote>` | `Quote` |
+| トグル | `<details>` + `<summary>` | `Toggle` + `ToggleTitle` |
+| 区切り線 | `<hr>` | — |
+| コード | `<pre>` | — |
+| 画像 | `<img>` | `ImageBlock` |
+| 動画 | `<figure>` | `Video` |
+| 音声 | `<figure>` | `Audio` |
+| ファイル | `<div>` | `FileBlock` |
+| PDF | `<figure>` | `PdfBlock` |
+| テーブル | `<table>` | `TableBlock` |
+| 目次 | `<nav>` | `TableOfContents` |
+| カラム / カラム内 | `<div>` / `<div>` | `Columns` / `Column` |
+| ページリンク | `<a>` | `PageRef` |
+| データベースリンク | `<a>` | `DatabaseRef` |
+| 空白ブロック | `<div>` | `EmptyBlock` |
+| インラインテキスト（色/下線） | `<span>` | `StyledSpan` |
+| @メンション | `<span>` | `Mention` |
+| 日付メンション | `<time>` | `MentionDate` |
+
+`notro-ui`はオプションのスタイルレイヤーです。詳細は[notro-ui](https://github.com/mosugi/notro/tree/main/packages/notro-ui)を参照してください。
+
+## 画像の扱い
+
+`notro-loader/image-service`はAstroのSharp画像サービスをラップした`notionImageService`をエクスポートします。
+
+Notionは画像を署名付きS3 URLで配信しますが、そのクエリパラメータ（`X-Amz-*`）はおよそ1時間で期限切れになります。Astroは画像のキャッシュキーをURL全体から算出するため、ビルドのたびに新しいURLが発行されると通常はキャッシュミスとなり毎回再最適化が走ってしまいます。`notionImageService`はキャッシュキー計算前に期限切れとなるパラメータを取り除くため、元のファイルが変わらない限り最適化済みの出力がビルド間で再利用されます。
+
+```js
+// astro.config.mjs
+import { notionImageService } from "notro-loader/image-service";
+
+export default defineConfig({
+  image: { service: notionImageService },
+});
+```
+
+このキャッシュの仕組みを有効にするため、Notionの画像には生の`<img>`タグではなく必ずAstroの`<Image />`コンポーネントを使用してください。
+
+## Markdown前処理（`preprocessNotionMarkdown`）
+
+`preprocessNotionMarkdown()`は、Sätteriの`evaluate()`に渡す前に、Notionが出力する生のMarkdownの構造上の問題を修正します。例えば、直前に空行がない`---`区切り線、レガシーな`:::callout{…}`ディレクティブ構文、CommonMarkが後続の内容を生のHTMLとして飲み込んでしまわないよう閉じタグの後に空行を追加する処理などです。
+
+これは`notro-loader`に組み込まれており、`NotroContent`や`notro()`インテグレーションを使う際は設定不要で自動的に適用されます。カスタムのコンパイルパイプラインで必要な場合に備え、直接エクスポートもされています。
+
+```typescript
+import { preprocessNotionMarkdown } from "notro-loader/utils";
+```
+
+> [!NOTE]
+> 以前のバージョンのnotro-loaderでは、この処理を独立した`remark-notro`パッケージに委譲していました。同パッケージは廃止済みで、`preprocessNotionMarkdown()`は現在`notro-loader`本体に組み込まれており、`notro-loader`と`notro-loader/utils`の両方からエクスポートされています。
+
+## Notion APIの制約
+
+> 参照：[Retrieve a page as Markdown – Notion API](https://developers.notion.com/reference/retrieve-page-markdown)
+
+### コンテンツの切り詰め（`truncated`）
+
+`GET /v1/pages/{page_id}/markdown`は、約**20,000ブロック**を超えるとコンテンツを切り詰めます。
+
+- レスポンスの`truncated: true`で判定できますが、**残りを取得するページネーションAPIはありません**
+- notroは`truncated === true`の場合に警告を出し、取得できた内容のままビルドを継続します
+- 回避策：巨大なNotionページを複数の小さなページに分割してください
+
+```
+⚠ Page abc123: markdown content was truncated by the Notion API (~20,000 block limit).
+  No pagination is available for this endpoint.
+  Consider splitting this Notion page into smaller pages to avoid truncation.
+```
+
+### 描画できないブロック（`unknown_block_ids`）
+
+レスポンスの`unknown_block_ids`には、Notion APIがMarkdownに変換できなかったブロックのID（未対応のブロック種別など）が列挙されます。
+
+- これらのブロックは`markdown`フィールドから**黙って除外**されます
+- このエンドポイント経由でその内容を取得する方法はありません
+- notroはブロックIDを警告として出力し、ビルドを継続します
+
+```
+⚠ Page abc123: 2 block(s) could not be rendered to Markdown by the Notion API and were omitted.
+  Block IDs: xxxxxxxx-..., yyyyyyyy-...
+```
+
+### APIエラーと自動リトライ
+
+| エラー | 挙動 |
+|---|---|
+| `429 rate_limited` / `500 internal_server_error` / `503 service_unavailable` | 指数バックオフでリトライ（1秒 / 2秒 / 4秒、最大3回） |
+| `401 unauthorized` / `403 restricted_resource` / `404 object_not_found` | リトライなし。警告を出しページをスキップ |
+| その他の予期しないエラー | 警告を出しページをスキップ（ビルド自体は継続） |
+
+## 環境変数
+
+| 変数 | 説明 |
+|---|---|
+| `NOTION_TOKEN` | Notion Internal Integration Token |
+| `NOTION_DATASOURCE_ID` | Notionデータソースの ID |
+
+## APIリファレンス
+
+### コンポーネント
+
+| コンポーネント | 説明 |
+|---|---|
+| `NotroContent` | NotionのMarkdownをHTMLとして描画します。デフォルトではスタイルなし、`components`でカスタマイズ可能 |
+| `DatabaseCover` | 最適化されたNotionのカバー画像を描画します |
+| `DatabaseProperty` | Notionのプロパティ値をその型に応じて描画します |
+| `compileMdxCached` | 低レベルのMDXコンパイルAPI。独自の`NotroContent`を構築する場合に使用します |
+
+### Loader
+
+| エクスポート | 説明 |
+|---|---|
+| `loader(options)` | Astro Content Loader。オプションは[`src/content.config.ts`](#2-srccontentconfigts)を参照してください |
+| `liveLoader(options)` | `loader()`のLive Content Collections版 |
+| `pageWithMarkdownSchema` | Loaderが返す基本のZodスキーマ。`pageObjectResponseSchema`に`markdown: z.string()`を追加したもの。`.extend()`でカスタムスキーマを定義できます |
+
+### `notroProperties`
+
+`content.config.ts`でデータベースのプロパティ型を定義するためのZodスキーマのショートハンドです。各キーはNotionのプロパティ型に対応します。
+
+```typescript
+import { notroProperties } from "notro-loader";
+
+// notroProperties.title       → titlePropertyPageObjectResponseSchema
+// notroProperties.richText    → richTextPropertyPageObjectResponseSchema
+// notroProperties.checkbox    → checkboxPropertyPageObjectResponseSchema
+// notroProperties.multiSelect → multiSelectPropertyPageObjectResponseSchema
+// notroProperties.select      → selectPropertyPageObjectResponseSchema
+// notroProperties.date        → datePropertyPageObjectResponseSchema
+// notroProperties.number      → numberPropertyPageObjectResponseSchema
+// notroProperties.url         → urlPropertyPageObjectResponseSchema
+// notroProperties.email       → emailPropertyPageObjectResponseSchema
+// notroProperties.phoneNumber → phoneNumberPropertyPageObjectResponseSchema
+// notroProperties.files       → filesPropertyPageObjectResponseSchema
+// notroProperties.people      → peoplePropertyPageObjectResponseSchema
+// notroProperties.relation    → relationPropertyPageObjectResponseSchema
+// notroProperties.rollup      → rollupPropertyPageObjectResponseSchema
+// notroProperties.formula     → formulaPropertyPageObjectResponseSchema
+// notroProperties.uniqueId    → uniqueIdPropertyPageObjectResponseSchema
+// notroProperties.status      → statusPropertyPageObjectResponseSchema
+// notroProperties.createdTime → createdTimePropertyPageObjectResponseSchema
+// notroProperties.createdBy   → createdByPropertyPageObjectResponseSchema
+// notroProperties.lastEditedTime → lastEditedTimePropertyPageObjectResponseSchema
+// notroProperties.lastEditedBy   → lastEditedByPropertyPageObjectResponseSchema
+// notroProperties.button      → buttonPropertyPageObjectResponseSchema
+// notroProperties.verification → verificationPropertyPageObjectResponseSchema
+```
+
+個別のスキーマ（例：`titlePropertyPageObjectResponseSchema`）も後方互換性のため引き続きエクスポートされています。
+
+### ユーティリティ
+
+| 関数 | 説明 |
+|---|---|
+| `getPlainText(property)` | Title、Rich Text、Select、Multi-select、Number、URL、Email、Phone、Date、Unique IDの各プロパティからプレーンテキストを抽出します |
+| `getMultiSelect(property)` | multi-selectプロパティのオプション配列を返します。未対応の型や`undefined`の場合は空配列を返すため、型ガードは不要です |
+| `hasTag(property, tagName)` | multi-selectプロパティに指定したタグ名が含まれるかを返します。型ガードなしで安全に呼び出せます |
+| `buildLinkToPages(entries, options)` | コレクションのエントリーから`linkToPages`マップを構築します。`NotroContent`に渡してページ間リンクを解決するのに使います |
+| `colorToCSS(color)` | Notionのカラー名をインラインCSSのスタイル文字列に変換します（カスタムコンポーネントでの利用向け） |
+| `preprocessNotionMarkdown(markdown)` | MDXコンパイル前にNotionの生Markdownの構造上の問題を修正します。`NotroContent`と`notro()`が自動的に適用します — 詳細は[Markdown前処理](#markdown前処理preprocessnotionmarkdown)を参照してください |
+| `normalizeNotionPresignedUrl(url)` | Notion S3 URLから期限切れとなる`X-Amz-*`クエリパラメータを取り除きます。`notionImageService`が内部的に使用します |

--- a/packages/notro-loader/README.ja.md
+++ b/packages/notro-loader/README.ja.md
@@ -201,8 +201,8 @@ const { entry } = Astro.props;
 | プロパティ | 型 | 用途 |
 |---|---|---|
 | `linkToPages` | `Record<string, { url: string; title: string }>` | Notionのページ内リンクを解決します。`buildLinkToPages()`で構築します |
-| `classMap` | `Partial<Record<ClassMapKeys, string>>` | デフォルトコンポーネントを置き換えずにTailwindクラスを注入します |
-| `components` | `Partial<NotionComponents>` | コンポーネントの完全な上書き（例：`{ Callout: MyCallout }`） |
+| `components` | `Record<string, unknown>` | コンポーネントの完全な上書き（例：`{ Callout: MyCallout }`）。デフォルトのヘッドレスコンポーネントにマージされます |
+| `class` | `string` | ラップする`<div>`に適用されるクラス |
 
 ## `NotroContent`が描画するもの
 
@@ -255,7 +255,7 @@ export default defineConfig({
 
 `preprocessNotionMarkdown()`は、Sätteriの`evaluate()`に渡す前に、Notionが出力する生のMarkdownの構造上の問題を修正します。例えば、直前に空行がない`---`区切り線、レガシーな`:::callout{…}`ディレクティブ構文、CommonMarkが後続の内容を生のHTMLとして飲み込んでしまわないよう閉じタグの後に空行を追加する処理などです。
 
-これは`notro-loader`に組み込まれており、`NotroContent`や`notro()`インテグレーションを使う際は設定不要で自動的に適用されます。カスタムのコンパイルパイプラインで必要な場合に備え、直接エクスポートもされています。
+これは`notro-loader`に組み込まれており、`NotroContent`を使う際は設定不要で自動的に適用されます。ただしこのランタイムのNotionコンテンツ経路でのみ実行され、`notro()`インテグレーション経由でコンパイルされる静的な`.mdx`ファイルには適用**されません**（Notion APIの出力ではないため、この種の構造上のクセを持たないからです）。カスタムのコンパイルパイプラインで必要な場合に備え、直接エクスポートもされています。
 
 ```typescript
 import { preprocessNotionMarkdown } from "notro-loader/utils";
@@ -372,5 +372,5 @@ import { notroProperties } from "notro-loader";
 | `hasTag(property, tagName)` | multi-selectプロパティに指定したタグ名が含まれるかを返します。型ガードなしで安全に呼び出せます |
 | `buildLinkToPages(entries, options)` | コレクションのエントリーから`linkToPages`マップを構築します。`NotroContent`に渡してページ間リンクを解決するのに使います |
 | `colorToCSS(color)` | Notionのカラー名をインラインCSSのスタイル文字列に変換します（カスタムコンポーネントでの利用向け） |
-| `preprocessNotionMarkdown(markdown)` | MDXコンパイル前にNotionの生Markdownの構造上の問題を修正します。`NotroContent`と`notro()`が自動的に適用します — 詳細は[Markdown前処理](#markdown前処理preprocessnotionmarkdown)を参照してください |
+| `preprocessNotionMarkdown(markdown)` | MDXコンパイル前にNotionの生Markdownの構造上の問題を修正します。`NotroContent`が自動的に適用します — 詳細は[Markdown前処理](#markdown前処理preprocessnotionmarkdown)を参照してください |
 | `normalizeNotionPresignedUrl(url)` | Notion S3 URLから期限切れとなる`X-Amz-*`クエリパラメータを取り除きます。`notionImageService`が内部的に使用します |

--- a/packages/notro-loader/README.md
+++ b/packages/notro-loader/README.md
@@ -3,40 +3,36 @@
 ![npm](https://img.shields.io/npm/v/notro-loader)
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue)
 
-An Astro Content Loader library that fetches Notion database content via the [Markdown Content API](https://developers.notion.com/) into [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/).
+An Astro Content Loader library that fetches Notion database content via the [Markdown Content API](https://developers.notion.com/) into [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/), compiles it with Sätteri (Astro 7's Rust-based Markdown/MDX processor), and renders it with a full set of Notion block components.
 
 > [!TIP]
 > This package is part of the [mosugi/notro](https://github.com/mosugi/notro) monorepo. See the blog template at `templates/blog/` for a full working example.
 
-## What NotroContent renders
+## Table of contents
 
-`NotroContent` compiles Notion markdown into HTML. Each Notion block type maps to a semantic HTML element by default. You can replace any element with your own styled component via the `components` prop.
+- [Entry points](#entry-points)
+- [Installation](#installation)
+- [Setup](#setup)
+  1. [`astro.config.mjs`](#1-astroconfigmjs)
+  2. [`src/content.config.ts`](#2-srccontentconfigts)
+  3. [Page component](#3-page-component)
+- [What `NotroContent` renders](#what-notrocontent-renders)
+- [Image handling](#image-handling)
+- [Markdown preprocessing (`preprocessNotionMarkdown`)](#markdown-preprocessing-preprocessnotionmarkdown)
+- [Notion API limitations](#notion-api-limitations)
+- [Environment variables](#environment-variables)
+- [API reference](#api-reference)
 
-| Notion block | Default HTML | notro-ui component |
+## Entry points
+
+`notro-loader` exposes four entry points, each scoped to where it's safe to import:
+
+| Entry point | Import | Use case |
 |---|---|---|
-| Paragraph | `<p>` | `ColoredParagraph` |
-| Heading 1–4 | `<h1>`–`<h4>` | `H1`–`H4` |
-| Callout | `<aside>` | `Callout` |
-| Quote | `<blockquote>` | `Quote` |
-| Toggle | `<details>` + `<summary>` | `Toggle` + `ToggleTitle` |
-| Divider | `<hr>` | — |
-| Code | `<pre>` | — |
-| Image | `<img>` | `ImageBlock` |
-| Video | `<figure>` | `Video` |
-| Audio | `<figure>` | `Audio` |
-| File | `<div>` | `FileBlock` |
-| PDF | `<figure>` | `PdfBlock` |
-| Table | `<table>` | `TableBlock` |
-| Table of contents | `<nav>` | `TableOfContents` |
-| Columns / Column | `<div>` / `<div>` | `Columns` / `Column` |
-| Page link | `<a>` | `PageRef` |
-| Database link | `<a>` | `DatabaseRef` |
-| Empty block | `<div>` | `EmptyBlock` |
-| Inline text (colored/underline) | `<span>` | `StyledSpan` |
-| @mention | `<span>` | `Mention` |
-| Date mention | `<time>` | `MentionDate` |
-
-`notro-ui` is an optional style layer. See [notro-ui](https://github.com/mosugi/notro/tree/main/packages/notro-ui) for details.
+| `notro-loader` | `import { NotroContent, loader, ... } from "notro-loader"` | Astro components and the Content Loader. **Cannot** be used in `astro.config.mjs` — Astro config is evaluated before the JSX renderer is registered. |
+| `notro-loader/utils` | `import { getPlainText, preprocessNotionMarkdown, ... } from "notro-loader/utils"` | Pure TypeScript helpers with no Astro component imports. Safe anywhere: config files, Node scripts, image services. |
+| `notro-loader/integration` | `import { notro } from "notro-loader/integration"` | The `notro()` Astro integration. Used in `astro.config.mjs` to register `@astrojs/mdx` with the correct Sätteri plugin pipeline. |
+| `notro-loader/image-service` | `import { notionImageService } from "notro-loader/image-service"` | Astro image service that strips expiring `X-Amz-*` query params from Notion S3 URLs before the cache key is computed. Used in `astro.config.mjs` under `image.service`. |
 
 ## Installation
 
@@ -56,18 +52,47 @@ npm install notro-loader
 
 ### 1. `astro.config.mjs`
 
-`astro add notro-loader` configures this automatically. If you installed manually, add:
+`astro add notro-loader` configures this automatically. If you installed manually, add the integration and (optionally) the image service:
 
 ```js
 import { defineConfig } from "astro/config";
 import { notro } from "notro-loader/integration";
+import { notionImageService } from "notro-loader/image-service";
 
 export default defineConfig({
+  image: { service: notionImageService },
   integrations: [notro()],
 });
 ```
 
-This registers `@astrojs/mdx` with the required plugin pipeline and the Astro JSX renderer that `NotroContent` depends on at runtime.
+`notro()` registers `@astrojs/mdx` with the required Sätteri plugin pipeline and the `astro:jsx` renderer that `NotroContent` depends on at runtime. With no options, it applies only its core Notion plugins (color classes, component renames, heading slugs, table of contents, page-link resolution). Rich features are opt-in:
+
+| Option | Type | Purpose |
+|---|---|---|
+| `mdastPlugins` | `MdastPluginInput[]` | Sätteri mdast plugins run after notro's core plugins (e.g. a KaTeX plugin for math) |
+| `hastPlugins` | `HastPluginInput[]` | Sätteri hast plugins run after renames, before slugs/TOC (e.g. [`satteri-beautiful-mermaid`](https://github.com/mosugi/notro/tree/main/packages/satteri-beautiful-mermaid)) |
+| `features` | `Features` | Extra Sätteri parser features merged over notro's defaults (e.g. `{ math: true }`) |
+| `shikiConfig` | `Record<string, unknown>` | Injects a Shiki hast plugin as the last user plugin (requires `npm install shiki`). Example: `{ theme: 'github-dark' }` |
+| `viteExternals` | `string[]` | Packages to add to Vite's `ssr.external` (for native binaries or dynamic imports) |
+| `extendMarkdownConfig` | `boolean` | Whether to extend Astro's base markdown config (default: `false`) |
+
+remark/rehype plugins are **not** supported — Astro 7 deprecated `markdown.remarkPlugins` / `rehypePlugins` and Sätteri cannot run them. Use Sätteri's mdast/hast plugin API instead ([docs](https://satteri.bruits.org/docs/plugins/)).
+
+```js
+import { defineConfig } from "astro/config";
+import { notro } from "notro-loader/integration";
+import { satteriMermaid } from "satteri-beautiful-mermaid";
+
+export default defineConfig({
+  integrations: [
+    notro({
+      shikiConfig: { theme: "github-dark" },
+      features: { math: true },
+      hastPlugins: [satteriMermaid({ theme: "github-dark" })],
+    }),
+  ],
+});
+```
 
 ### 2. `src/content.config.ts`
 
@@ -104,6 +129,25 @@ const posts = defineCollection({
 
 export const collections = { posts };
 ```
+
+`loader(options)` accepts:
+
+| Option | Type | Purpose |
+|---|---|---|
+| `queryParameters` | `QueryDataSourceParameters` | Passed directly to the Notion API's `dataSources.query` |
+| `clientOptions` | `ConstructorParameters<typeof Client>[0]` | Passed to the `@notionhq/client` constructor (e.g. `{ auth }`) |
+| `generateId` | `(page) => string` (optional) | Custom entry ID per page. Defaults to the Notion page UUID. Use when the entry ID must match a specific format (e.g. Starlight sidebar slugs) |
+| `useFilePath` | `boolean` (optional, default `false`) | Sets a synthetic `filePath` on each store entry so Starlight's sidebar autogenerate can resolve route paths. Only needed with `@astrojs/starlight` |
+
+The loader caches pages by `last_edited_time` digest and re-fetches entries that are deleted, edited, or contain expired Notion pre-signed S3 URLs.
+
+A live-reload variant is also available for Astro's [Live Content Collections](https://docs.astro.build/en/guides/content-collections/#live-content-collections):
+
+```typescript
+import { liveLoader } from "notro-loader";
+```
+
+It takes the same `queryParameters` / `clientOptions` shape as `loader()`.
 
 ### 3. Page component
 
@@ -144,23 +188,75 @@ const { entry } = Astro.props;
 <NotroContent markdown={entry.data.markdown} components={notroComponents} />
 ```
 
-Components are copied into `src/components/notro/` so you can edit them directly.
+Components are copied into `src/components/notro/` so you can edit them directly. See [notro-ui](https://github.com/mosugi/notro/tree/main/packages/notro-ui) for details.
 
-## Markdown processing (remark-notro)
+Optional `NotroContent` props:
 
-`notro-loader` delegates Notion Markdown preprocessing and directive syntax support to the [`remark-notro`](https://www.npmjs.com/package/remark-notro) package.
+| Prop | Type | Purpose |
+|---|---|---|
+| `linkToPages` | `Record<string, { url: string; title: string }>` | Resolves internal Notion page links. Build it with `buildLinkToPages()` |
+| `classMap` | `Partial<Record<ClassMapKeys, string>>` | Injects Tailwind classes into default components without replacing them |
+| `components` | `Partial<NotionComponents>` | Full component overrides (e.g. `{ Callout: MyCallout }`) |
 
-`remark-notro` is used inside notro-loader's MDX compile pipeline and is applied automatically when using `NotroContent`.
+## What `NotroContent` renders
 
-If you want to use `remark-notro` directly (in a custom unified pipeline or `@mdx-js/mdx`'s `evaluate()`), import it from the `remark-notro` package directly rather than from `notro-loader`.
+`NotroContent` compiles Notion markdown into HTML. Each Notion block type maps to a semantic HTML element by default. You can replace any element with your own styled component via the `components` prop.
 
-```ts
-// ✅ Import directly from remark-notro
-import { remarkNfm, preprocessNotionMarkdown } from "remark-notro";
+| Notion block | Default HTML | notro-ui component |
+|---|---|---|
+| Paragraph | `<p>` | `ColoredParagraph` |
+| Heading 1–4 | `<h1>`–`<h4>` | `H1`–`H4` |
+| Callout | `<aside>` | `Callout` |
+| Quote | `<blockquote>` | `Quote` |
+| Toggle | `<details>` + `<summary>` | `Toggle` + `ToggleTitle` |
+| Divider | `<hr>` | — |
+| Code | `<pre>` | — |
+| Image | `<img>` | `ImageBlock` |
+| Video | `<figure>` | `Video` |
+| Audio | `<figure>` | `Audio` |
+| File | `<div>` | `FileBlock` |
+| PDF | `<figure>` | `PdfBlock` |
+| Table | `<table>` | `TableBlock` |
+| Table of contents | `<nav>` | `TableOfContents` |
+| Columns / Column | `<div>` / `<div>` | `Columns` / `Column` |
+| Page link | `<a>` | `PageRef` |
+| Database link | `<a>` | `DatabaseRef` |
+| Empty block | `<div>` | `EmptyBlock` |
+| Inline text (colored/underline) | `<span>` | `StyledSpan` |
+| @mention | `<span>` | `Mention` |
+| Date mention | `<time>` | `MentionDate` |
 
-// ❌ Not needed from notro-loader (internal use only)
-// import { remarkNfm } from "notro-loader";
+`notro-ui` is an optional style layer. See [notro-ui](https://github.com/mosugi/notro/tree/main/packages/notro-ui) for details.
+
+## Image handling
+
+`notro-loader/image-service` exports `notionImageService`, an Astro image service that wraps Astro's Sharp service.
+
+Notion serves images from pre-signed S3 URLs whose query parameters (`X-Amz-*`) expire after roughly an hour. Astro derives its image cache key from the full URL, so a fresh URL on every build normally forces re-optimization every time. `notionImageService` strips the expiring parameters before the cache key is computed, so the optimized output is reused across builds as long as the underlying file hasn't changed.
+
+```js
+// astro.config.mjs
+import { notionImageService } from "notro-loader/image-service";
+
+export default defineConfig({
+  image: { service: notionImageService },
+});
 ```
+
+Always use Astro's `<Image />` component for Notion images rather than a raw `<img>` tag, so this caching behavior takes effect.
+
+## Markdown preprocessing (`preprocessNotionMarkdown`)
+
+`preprocessNotionMarkdown()` fixes structural issues in Notion's raw Markdown output before it's handed to Sätteri's `evaluate()` — things like `---` dividers without a preceding blank line, legacy `:::callout{…}` directive syntax, and closing tags that need a trailing blank line so CommonMark doesn't swallow the following content as raw HTML.
+
+It's built into `notro-loader` and is applied automatically whenever you use `NotroContent` or the `notro()` integration — no setup required. It's also exported directly, in case you need it in a custom compile pipeline:
+
+```typescript
+import { preprocessNotionMarkdown } from "notro-loader/utils";
+```
+
+> [!NOTE]
+> Earlier versions of notro-loader delegated this step to a separate `remark-notro` package. That package has been discontinued — `preprocessNotionMarkdown()` now lives in `notro-loader` itself, exported from both `notro-loader` and `notro-loader/utils`.
 
 ## Notion API limitations
 
@@ -208,21 +304,7 @@ import { remarkNfm, preprocessNotionMarkdown } from "remark-notro";
 | `NOTION_TOKEN` | Notion Internal Integration Token |
 | `NOTION_DATASOURCE_ID` | Notion data source ID |
 
-## API Reference
-
-### `loader(options)`
-
-Astro Content Loader. Pass Notion API `dataSources.query` parameters via `queryParameters`.
-
-### `pageWithMarkdownSchema`
-
-Base Zod schema returned by the loader. Extends `pageObjectResponseSchema` with `markdown: z.string()`. Extend with `.extend()` for custom schemas.
-
-### Property schemas
-
-Use the `notroProperties` shorthand to define database property types in `content.config.ts` (see [`notroProperties`](#notroproperties)).
-
-Individual schemas (e.g. `titlePropertyPageObjectResponseSchema`) remain exported for backwards compatibility.
+## API reference
 
 ### Components
 
@@ -232,6 +314,14 @@ Individual schemas (e.g. `titlePropertyPageObjectResponseSchema`) remain exporte
 | `DatabaseCover` | Renders a Notion cover image with optimization |
 | `DatabaseProperty` | Renders a Notion property value by type |
 | `compileMdxCached` | Low-level MDX compile API. Use when building a custom `NotroContent` |
+
+### Loader
+
+| Export | Description |
+|---|---|
+| `loader(options)` | Astro Content Loader. See [`src/content.config.ts`](#2-srccontentconfigts) for options |
+| `liveLoader(options)` | Live Content Collections variant of `loader()` |
+| `pageWithMarkdownSchema` | Base Zod schema returned by the loader. Extends `pageObjectResponseSchema` with `markdown: z.string()`. Extend with `.extend()` for custom schemas |
 
 ### `notroProperties`
 
@@ -265,6 +355,8 @@ import { notroProperties } from "notro-loader";
 // notroProperties.verification → verificationPropertyPageObjectResponseSchema
 ```
 
+Individual schemas (e.g. `titlePropertyPageObjectResponseSchema`) remain exported for backwards compatibility.
+
 ### Utilities
 
 | Function | Description |
@@ -274,3 +366,5 @@ import { notroProperties } from "notro-loader";
 | `hasTag(property, tagName)` | Returns whether a multi-select property contains the given tag name. Safe to call without a type guard |
 | `buildLinkToPages(entries, options)` | Builds a `linkToPages` map from collection entries. Pass to `NotroContent` for resolving inter-page Notion links |
 | `colorToCSS(color)` | Converts a Notion color name to an inline CSS style string (for use in custom components) |
+| `preprocessNotionMarkdown(markdown)` | Fixes structural issues in Notion's raw Markdown before MDX compilation. Applied automatically by `NotroContent` and `notro()` — see [Markdown preprocessing](#markdown-preprocessing-preprocessnotionmarkdown) |
+| `normalizeNotionPresignedUrl(url)` | Strips expiring `X-Amz-*` query params from a Notion S3 URL. Used internally by `notionImageService` |

--- a/packages/notro-loader/README.md
+++ b/packages/notro-loader/README.md
@@ -201,8 +201,8 @@ Optional `NotroContent` props:
 | Prop | Type | Purpose |
 |---|---|---|
 | `linkToPages` | `Record<string, { url: string; title: string }>` | Resolves internal Notion page links. Build it with `buildLinkToPages()` |
-| `classMap` | `Partial<Record<ClassMapKeys, string>>` | Injects Tailwind classes into default components without replacing them |
-| `components` | `Partial<NotionComponents>` | Full component overrides (e.g. `{ Callout: MyCallout }`) |
+| `components` | `Record<string, unknown>` | Full component overrides (e.g. `{ Callout: MyCallout }`). Merged over the default headless components |
+| `class` | `string` | Class applied to the wrapping `<div>` |
 
 ## What `NotroContent` renders
 
@@ -255,7 +255,7 @@ Always use Astro's `<Image />` component for Notion images rather than a raw `<i
 
 `preprocessNotionMarkdown()` fixes structural issues in Notion's raw Markdown output before it's handed to Sätteri's `evaluate()` — things like `---` dividers without a preceding blank line, legacy `:::callout{…}` directive syntax, and closing tags that need a trailing blank line so CommonMark doesn't swallow the following content as raw HTML.
 
-It's built into `notro-loader` and is applied automatically whenever you use `NotroContent` or the `notro()` integration — no setup required. It's also exported directly, in case you need it in a custom compile pipeline:
+It's built into `notro-loader` and is applied automatically whenever you use `NotroContent` — no setup required. It runs only on that runtime Notion-content path; static `.mdx` files compiled through the `notro()` integration are **not** run through it, since they aren't Notion API output and don't have these quirks. It's also exported directly, in case you need it in a custom compile pipeline:
 
 ```typescript
 import { preprocessNotionMarkdown } from "notro-loader/utils";
@@ -372,5 +372,5 @@ Individual schemas (e.g. `titlePropertyPageObjectResponseSchema`) remain exporte
 | `hasTag(property, tagName)` | Returns whether a multi-select property contains the given tag name. Safe to call without a type guard |
 | `buildLinkToPages(entries, options)` | Builds a `linkToPages` map from collection entries. Pass to `NotroContent` for resolving inter-page Notion links |
 | `colorToCSS(color)` | Converts a Notion color name to an inline CSS style string (for use in custom components) |
-| `preprocessNotionMarkdown(markdown)` | Fixes structural issues in Notion's raw Markdown before MDX compilation. Applied automatically by `NotroContent` and `notro()` — see [Markdown preprocessing](#markdown-preprocessing-preprocessnotionmarkdown) |
+| `preprocessNotionMarkdown(markdown)` | Fixes structural issues in Notion's raw Markdown before MDX compilation. Applied automatically by `NotroContent` — see [Markdown preprocessing](#markdown-preprocessing-preprocessnotionmarkdown) |
 | `normalizeNotionPresignedUrl(url)` | Strips expiring `X-Amz-*` query params from a Notion S3 URL. Used internally by `notionImageService` |

--- a/packages/notro-loader/README.md
+++ b/packages/notro-loader/README.md
@@ -1,5 +1,11 @@
 # notro-loader
 
+<p>
+<a href="README.md">English</a>
+ | 
+<a href="./README.ja.md">日本語</a>
+</p>
+
 ![npm](https://img.shields.io/npm/v/notro-loader)
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue)
 


### PR DESCRIPTION
## Summary

Restructured the `notro-loader` README to improve discoverability and clarity for users. The documentation now leads with entry points, provides a comprehensive setup guide with configuration examples, and reorganizes the API reference for better navigation.

## Key Changes

- **Added Table of Contents** – New section at the top with links to all major sections for easier navigation
- **New "Entry Points" section** – Documents the four import paths (`notro-loader`, `notro-loader/utils`, `notro-loader/integration`, `notro-loader/image-service`) and their use cases upfront
- **Expanded Setup Guide** – Moved and enhanced the `astro.config.mjs` section with:
  - Integration options table (mdastPlugins, hastPlugins, features, shikiConfig, viteExternals, extendMarkdownConfig)
  - Code example showing Shiki + Mermaid + Math configuration
  - Clarification that remark/rehype plugins are not supported in Astro 7
- **New "Image Handling" section** – Dedicated documentation for `notionImageService`, explaining the S3 pre-signed URL caching behavior and best practices
- **Renamed "Markdown preprocessing" section** – Moved `preprocessNotionMarkdown()` documentation to its own section with context about the deprecated `remark-notro` package
- **Enhanced `loader()` documentation** – Added options table with `queryParameters`, `clientOptions`, `generateId`, and `useFilePath`; documented `liveLoader()` variant
- **Reorganized API Reference** – Split into logical subsections (Components, Loader, notroProperties, Utilities) with clearer descriptions
- **Updated Utilities table** – Added `preprocessNotionMarkdown()` and `normalizeNotionPresignedUrl()` with descriptions
- **Removed outdated content** – Deleted references to `remark-notro` as a separate package; consolidated all preprocessing documentation into notro-loader

## Implementation Details

- Moved the "What NotroContent renders" block table to appear after the setup sections, maintaining its content but improving flow
- Clarified that `notro-ui` components are optional and linked to the notro-ui package for details
- Added context about Notion API limitations and environment variables in their existing sections
- Improved cross-references between sections (e.g., linking setup steps to detailed option tables)

https://claude.ai/code/session_01DucBd1PmZU4BUgREt6hQjC